### PR TITLE
feat(tui): add event response modal with quick accept

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Accept, decline, or tentatively respond to calendar event invitations directly f
 tsk ui
 ```
 
-A proper TUI with an event list and detail panel, day-by-day navigation, a "NOW" marker that auto-scrolls to where you are, meeting link shortcuts, and merged duplicates across shared calendars.
+A proper TUI with an event list and detail panel, day-by-day navigation, a "NOW" marker that auto-scrolls to where you are, meeting link shortcuts, and merged duplicates across shared calendars. Quick-accept invitations with `a` or open the full respond modal with `r` to decline, go tentative, add messages, or propose new times.
 
 ## Documentation
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,14 +54,18 @@ tsk ui --list-percent 40
 | `←` / `→` | Previous / next day |
 | `t` | Jump to now (or jump to today if viewing another day) |
 | `tab` | Switch focus between list and detail panels |
-| `s` | Toggle split direction (side / stack) |
+| `/` | Toggle split direction (side / stack) |
 | `enter` | Open meeting link in browser |
+| `a` | Quick accept event (single click accept) |
+| `r` | Respond to event (full options modal) |
 | `v` | Open event in calendar (browser) |
-| `r` | Refresh events |
+| `s` | Sync / refresh events |
 | `ctrl+u` / `pgup` | Scroll detail panel up |
 | `ctrl+d` / `pgdown` | Scroll detail panel down |
 | `?` | Show help overlay |
 | `q` / `ctrl+c` | Quit |
+
+**Note:** The bottom help bar shows a simplified view with only the most common shortcuts. Press `?` to see the complete list of all available keyboard shortcuts.
 
 ### `tsk calendars`
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 h1:fou+2+WFTib47nS+nz/ozhEB
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0/go.mod h1:t76Ruy8AHvUAC8GfMWJMa0ElSbuIcO03NLpynfbgsPA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -19,20 +19,22 @@ import (
 
 // KeyMap defines the keybindings for the TUI
 type KeyMap struct {
-	Up         key.Binding
-	Down       key.Binding
-	ScrollUp   key.Binding
-	ScrollDown key.Binding
-	Open       key.Binding
-	ViewEvent  key.Binding
-	Refresh    key.Binding
-	NextDay    key.Binding
-	PrevDay    key.Binding
-	Today      key.Binding
-	Tab        key.Binding
-	Split      key.Binding
-	Quit       key.Binding
-	Help       key.Binding
+	Up          key.Binding
+	Down        key.Binding
+	ScrollUp    key.Binding
+	ScrollDown  key.Binding
+	Open        key.Binding
+	ViewEvent   key.Binding
+	QuickAccept key.Binding
+	Respond     key.Binding
+	Refresh     key.Binding
+	NextDay     key.Binding
+	PrevDay     key.Binding
+	Today       key.Binding
+	Tab         key.Binding
+	Split       key.Binding
+	Quit        key.Binding
+	Help        key.Binding
 }
 
 var DefaultKeyMap = KeyMap{
@@ -60,9 +62,17 @@ var DefaultKeyMap = KeyMap{
 		key.WithKeys("v"),
 		key.WithHelp("v", "view event"),
 	),
-	Refresh: key.NewBinding(
+	QuickAccept: key.NewBinding(
+		key.WithKeys("a"),
+		key.WithHelp("a", "accept"),
+	),
+	Respond: key.NewBinding(
 		key.WithKeys("r"),
-		key.WithHelp("r", "refresh"),
+		key.WithHelp("r", "respond"),
+	),
+	Refresh: key.NewBinding(
+		key.WithKeys("s"),
+		key.WithHelp("s", "sync"),
 	),
 	NextDay: key.NewBinding(
 		key.WithKeys("right"),
@@ -81,8 +91,8 @@ var DefaultKeyMap = KeyMap{
 		key.WithHelp("tab", "switch panel"),
 	),
 	Split: key.NewBinding(
-		key.WithKeys("s"),
-		key.WithHelp("s", "toggle split"),
+		key.WithKeys("/"),
+		key.WithHelp("/", "toggle split"),
 	),
 	Quit: key.NewBinding(
 		key.WithKeys("q", "ctrl+c"),
@@ -138,9 +148,12 @@ type Model struct {
 	viewportReady  bool
 	compactMode    bool           // True when terminal is too narrow for side-by-side
 	focusedPanel   PanelFocus     // Which panel is shown in compact mode
-	splitDirection SplitDirection // Vertical (side-by-side) or horizontal (stacked)
-	listPercent    int            // 0 = auto, 10-90 = user-configured list panel %
-	showHelp       bool           // Whether the help overlay is visible
+	splitDirection   SplitDirection // Vertical (side-by-side) or horizontal (stacked)
+	listPercent      int            // 0 = auto, 10-90 = user-configured list panel %
+	showHelp         bool           // Whether the help overlay is visible
+	showRespondModal bool           // Whether the respond modal is visible
+	respondModal     RespondModal   // The respond modal component
+	respondStatus    string         // Status message after responding
 }
 
 // NewModel creates a new TUI model
@@ -268,6 +281,11 @@ type eventsLoadedMsg struct {
 
 type tickMsg time.Time
 
+type responseSubmittedMsg struct {
+	success bool
+	err     error
+}
+
 // Commands
 func (m Model) loadEvents() tea.Cmd {
 	return func() tea.Msg {
@@ -288,6 +306,95 @@ func tickCmd() tea.Cmd {
 	return tea.Tick(time.Minute, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
+}
+
+// submitResponse sends the event response via the provider
+func (m Model) submitResponse(opts core.RespondOptions, proposalStr string, calendarID string) tea.Cmd {
+	return func() tea.Msg {
+		event := m.events[m.selectedIdx]
+		eventID := event.ID
+
+		// Parse proposed time if provided
+		if proposalStr != "" {
+			proposal, err := parseProposedTime(proposalStr, event.Start)
+			if err != nil {
+				return responseSubmittedMsg{success: false, err: fmt.Errorf("invalid proposed time: %w", err)}
+			}
+			opts.ProposedTime = proposal
+		}
+
+		// Submit response to provider
+		err := m.provider.RespondToEvent(context.Background(), calendarID, eventID, opts)
+		if err != nil {
+			return responseSubmittedMsg{success: false, err: err}
+		}
+
+		return responseSubmittedMsg{success: true}
+	}
+}
+
+// parseProposedTime parses a proposed time in the format "start/end"
+func parseProposedTime(proposal string, eventDate time.Time) (*core.TimeProposal, error) {
+	parts := strings.SplitN(proposal, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("expected format: start/end")
+	}
+
+	start, err := parseTimeWithEventDate(strings.TrimSpace(parts[0]), eventDate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid start time: %w", err)
+	}
+
+	end, err := parseTimeWithEventDate(strings.TrimSpace(parts[1]), eventDate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid end time: %w", err)
+	}
+
+	if !end.After(start) {
+		return nil, fmt.Errorf("end time must be after start time")
+	}
+
+	return &core.TimeProposal{
+		Start: start,
+		End:   end,
+	}, nil
+}
+
+// parseTimeWithEventDate parses a time string with smart defaults
+func parseTimeWithEventDate(timeStr string, eventDate time.Time) (time.Time, error) {
+	// Try parsing as full RFC3339 (with timezone)
+	t, err := time.Parse(time.RFC3339, timeStr)
+	if err == nil {
+		return t, nil
+	}
+
+	// Try parsing without timezone: 2006-01-02T15:04:05
+	t, err = time.ParseInLocation("2006-01-02T15:04:05", timeStr, time.Local)
+	if err == nil {
+		return t, nil
+	}
+
+	// Try parsing without timezone or seconds: 2006-01-02T15:04
+	t, err = time.ParseInLocation("2006-01-02T15:04", timeStr, time.Local)
+	if err == nil {
+		return t, nil
+	}
+
+	// Try parsing as time-only with seconds: 15:04:05
+	t, err = time.ParseInLocation("15:04:05", timeStr, time.Local)
+	if err == nil {
+		return time.Date(eventDate.Year(), eventDate.Month(), eventDate.Day(),
+			t.Hour(), t.Minute(), t.Second(), 0, time.Local), nil
+	}
+
+	// Try parsing as time-only without seconds: 15:04
+	t, err = time.ParseInLocation("15:04", timeStr, time.Local)
+	if err == nil {
+		return time.Date(eventDate.Year(), eventDate.Month(), eventDate.Day(),
+			t.Hour(), t.Minute(), 0, 0, time.Local), nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid time format")
 }
 
 // Init initializes the model
@@ -452,11 +559,47 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.updateDetailContent()
 		return m, tickCmd()
 
+	case responseSubmittedMsg:
+		m.showRespondModal = false
+		if msg.success {
+			m.respondStatus = "✓ Response sent successfully"
+			// Refresh events to show updated status
+			return m, m.loadEvents()
+		} else {
+			// Format error message nicely
+			m.respondStatus = m.formatRespondError(msg.err)
+		}
+		return m, nil
+
 	case tea.KeyMsg:
+		// When respond modal is shown, pass messages to it
+		if m.showRespondModal {
+			var cmd tea.Cmd
+			m.respondModal, cmd = m.respondModal.Update(msg)
+
+			// Check if modal was submitted or cancelled
+			if m.respondModal.Cancelled() {
+				m.showRespondModal = false
+				return m, nil
+			}
+
+			if opts, ok := m.respondModal.GetResponse(); ok {
+				// Handle response submission - use calendar ID from modal (handles multi-calendar)
+				return m, m.submitResponse(opts, m.respondModal.GetProposalString(), m.respondModal.calendarID)
+			}
+
+			return m, cmd
+		}
+
 		// When help overlay is shown, any key dismisses it
 		if m.showHelp {
 			m.showHelp = false
 			return m, nil
+		}
+
+		// Clear respond status on any key press (except when modal/help is showing)
+		if m.respondStatus != "" {
+			m.respondStatus = ""
 		}
 
 		switch {
@@ -577,6 +720,46 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			return m, nil
+
+		case key.Matches(msg, m.keys.QuickAccept):
+			// Quick accept - immediately accept the event without modal
+			if len(m.events) > 0 && m.selectedIdx < len(m.events) {
+				event := m.events[m.selectedIdx]
+				// Check if user can respond to this event
+				if event.Status != core.StatusNoResponse {
+					opts := core.RespondOptions{
+						Response:       core.ResponseAccept,
+						RecurringScope: core.RecurringScopeThisInstance,
+					}
+					m.respondStatus = "Accepting event..."
+					// Use primary calendar for quick accept
+					calendarID := event.Calendar.ID
+					return m, m.submitResponse(opts, "", calendarID)
+				} else {
+					// Show why user cannot respond
+					m.respondStatus = m.getCannotRespondMessage(event)
+				}
+			}
+			return m, nil
+
+		case key.Matches(msg, m.keys.Respond):
+			// Open respond modal if event is selected and user is an attendee
+			if len(m.events) > 0 && m.selectedIdx < len(m.events) {
+				event := m.events[m.selectedIdx]
+				// Check if user can respond to this event
+				if event.Status != core.StatusNoResponse {
+					m.respondModal = NewRespondModal(event, event.Calendar.ID)
+					m.respondModal.width = m.width
+					m.respondModal.height = m.height
+					m.showRespondModal = true
+					m.respondStatus = "" // Clear previous status
+					return m, m.respondModal.Init()
+				} else {
+					// Show why user cannot respond
+					m.respondStatus = m.getCannotRespondMessage(event)
+				}
+			}
+			return m, nil
 		}
 	}
 	return m, nil
@@ -636,12 +819,29 @@ func (m Model) View() string {
 		content = lipgloss.JoinHorizontal(lipgloss.Top, listPanel, " ", rightPanel)
 	}
 
-	// Help bar
+	// Help bar with optional status message
 	help := m.renderHelp()
+	if m.respondStatus != "" {
+		statusStyle := lipgloss.NewStyle().Foreground(primaryColor)
+		if strings.HasPrefix(m.respondStatus, "✗") {
+			statusStyle = statusStyle.Foreground(errorColor)
+		}
+		help = statusStyle.Render(m.respondStatus) + "  •  " + help
+	}
 
-	return AppStyle.Render(
+	baseView := AppStyle.Render(
 		lipgloss.JoinVertical(lipgloss.Left, header, content, help),
 	)
+
+	// Show respond modal overlay if active
+	if m.showRespondModal {
+		modal := m.respondModal.View()
+		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center,
+			lipgloss.JoinVertical(lipgloss.Center, baseView, modal),
+		)
+	}
+
+	return baseView
 }
 
 func (m Model) renderHeader() string {
@@ -1050,17 +1250,16 @@ func (m Model) renderDetailPanel() string {
 }
 
 func (m Model) renderHelp() string {
-	var keys []string
-
-	keys = []string{
-		HelpKeyStyle.Render("↑/↓") + " nav",
-		HelpKeyStyle.Render("←/→") + " day",
-		HelpKeyStyle.Render("tab") + " panel",
-		HelpKeyStyle.Render("s") + " split",
+	// Compact help bar - only the essentials
+	keys := []string{
+		HelpKeyStyle.Render("↑/↓/←/→") + " move",
 		HelpKeyStyle.Render("t") + " now",
 		HelpKeyStyle.Render("enter") + " meet",
+		HelpKeyStyle.Render("a") + " accept",
+		HelpKeyStyle.Render("r") + " respond",
 		HelpKeyStyle.Render("v") + " view",
-		HelpKeyStyle.Render("r") + " refresh",
+		HelpKeyStyle.Render("s") + " sync",
+		HelpKeyStyle.Render("?") + " help",
 		HelpKeyStyle.Render("q") + " quit",
 	}
 
@@ -1094,10 +1293,12 @@ func (m Model) renderHelpPanel() string {
 		HelpKeyStyle.Render("  ←          ") + " Previous day",
 		HelpKeyStyle.Render("  t          ") + " Jump to now / today",
 		HelpKeyStyle.Render("  tab        ") + " Switch panel",
-		HelpKeyStyle.Render("  s          ") + " Toggle split direction",
+		HelpKeyStyle.Render("  /          ") + " Toggle split direction",
 		HelpKeyStyle.Render("  enter      ") + " Start meeting / open event",
+		HelpKeyStyle.Render("  a          ") + " Quick accept event",
+		HelpKeyStyle.Render("  r          ") + " Respond to event (full options)",
 		HelpKeyStyle.Render("  v          ") + " View event in calendar",
-		HelpKeyStyle.Render("  r          ") + " Refresh events",
+		HelpKeyStyle.Render("  s          ") + " Sync / refresh events",
 		HelpKeyStyle.Render("  q / ctrl+c ") + " Quit",
 		"",
 		lipgloss.NewStyle().Foreground(mutedColor).Italic(true).Render("  Press any key to close"),
@@ -1196,6 +1397,72 @@ func formatStatus(status core.EventStatus) string {
 		return lipgloss.NewStyle().Foreground(mutedColor).Render("No response needed")
 	default:
 		return "Unknown"
+	}
+}
+
+// formatRespondError converts provider errors to user-friendly messages
+func (m Model) formatRespondError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	switch {
+	case strings.Contains(err.Error(), "insufficient"):
+		return "✗ Insufficient permissions - please re-authenticate with 'tsk auth'"
+	case strings.Contains(err.Error(), core.ErrNotAttendee.Error()):
+		return "✗ Cannot respond: You are not an attendee of this event"
+	case strings.Contains(err.Error(), core.ErrIsOrganizer.Error()):
+		return "✗ Cannot respond: You are the organizer of this event"
+	case strings.Contains(err.Error(), core.ErrNotImplemented.Error()):
+		return "✗ Response feature not yet supported for this calendar provider"
+	case strings.Contains(err.Error(), "cancelled"):
+		return "✗ Cannot respond: This event has been cancelled"
+	case strings.Contains(err.Error(), "invalid proposed time"):
+		// Extract the specific error for more helpful feedback
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "expected format: start/end") {
+			return "✗ Missing '/' separator - use format: 14:00/15:00"
+		} else if strings.Contains(errMsg, "end time must be after start time") {
+			return "✗ End time must be after start time"
+		} else if strings.Contains(errMsg, "invalid start time") {
+			return "✗ Invalid start time - use 14:00 or 2026-03-04T14:00"
+		} else if strings.Contains(errMsg, "invalid end time") {
+			return "✗ Invalid end time - use 15:00 or 2026-03-04T15:00"
+		}
+		return "✗ Invalid time format - use 14:00/15:00 or 2026-03-04T14:00/15:00"
+	default:
+		// Show the error but make it clearer
+		errMsg := err.Error()
+		if len(errMsg) > 80 {
+			errMsg = errMsg[:77] + "..."
+		}
+		return fmt.Sprintf("✗ Error: %s", errMsg)
+	}
+}
+
+// getCannotRespondMessage returns an appropriate error message for why the user cannot respond
+func (m Model) getCannotRespondMessage(event core.Event) string {
+	// Check if it's a subscribed calendar event (e.g., holidays, shared calendars)
+	if len(event.Calendars) > 0 {
+		// Check if this is from a subscribed calendar by looking at calendar types
+		for _, cal := range event.Calendars {
+			if cal.Status == core.StatusNoResponse {
+				return "✗ Cannot respond to subscribed calendar events"
+			}
+		}
+	}
+
+	// Check specific status reasons
+	switch event.Status {
+	case core.StatusNoResponse:
+		// Self-created event or subscribed calendar
+		if event.Calendar.Name != "" {
+			return fmt.Sprintf("✗ Cannot respond to events from \"%s\"", event.Calendar.Name)
+		}
+		return "✗ Cannot respond to this event (no response needed)"
+	default:
+		// Shouldn't reach here, but provide a generic message
+		return "✗ Cannot respond to this event"
 	}
 }
 

--- a/internal/tui/respond.go
+++ b/internal/tui/respond.go
@@ -1,0 +1,693 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/theakshaypant/tsk/internal/core"
+)
+
+// RespondModal is a form for responding to calendar events
+type RespondModal struct {
+	event               core.Event
+	calendarID          string
+	selectedCalendarIdx int // Index into event.Calendars for multi-calendar events
+	width               int
+	height              int
+	focusIndex          int
+	responseType        core.ResponseType
+	messageInput        textinput.Model
+	proposalInput       textinput.Model
+	recurringScope      core.RecurringScope
+	submitted           bool
+	cancelled           bool
+}
+
+// NewRespondModal creates a new respond modal for the given event
+func NewRespondModal(event core.Event, calendarID string) RespondModal {
+	messageInput := textinput.New()
+	messageInput.Placeholder = "Optional message to organizer..."
+	messageInput.CharLimit = 500
+	messageInput.Width = 50
+
+	proposalInput := textinput.New()
+	proposalInput.Placeholder = "14:00/15:00 or 2026-03-04T14:00/15:00"
+	proposalInput.CharLimit = 100
+	proposalInput.Width = 50
+
+	// Find which calendar index to use for multi-calendar events
+	selectedCalendarIdx := 0
+	if len(event.Calendars) > 1 {
+		// Find the calendar that matches the provided calendarID
+		for i, cal := range event.Calendars {
+			if cal.Calendar.ID == calendarID {
+				selectedCalendarIdx = i
+				break
+			}
+		}
+	}
+
+	// Pre-populate response type based on current status
+	// For multi-calendar events, use the status from the selected calendar
+	responseType := core.ResponseAccept
+	status := event.Status
+	if len(event.Calendars) > 0 && selectedCalendarIdx < len(event.Calendars) {
+		status = event.Calendars[selectedCalendarIdx].Status
+	}
+
+	switch status {
+	case core.StatusAccepted:
+		responseType = core.ResponseAccept
+	case core.StatusRejected:
+		responseType = core.ResponseDecline
+	case core.StatusTentative:
+		responseType = core.ResponseTentative
+	case core.StatusAwaiting:
+		responseType = core.ResponseAccept // Default for pending invitations
+	}
+
+	// Pre-populate proposed time if it exists
+	if proposal := event.GetProposedTime(); proposal != nil {
+		proposalStr := proposal.Start.Format("15:04") + "/" + proposal.End.Format("15:04")
+		proposalInput.SetValue(proposalStr)
+	}
+
+	return RespondModal{
+		event:               event,
+		calendarID:          calendarID,
+		selectedCalendarIdx: selectedCalendarIdx,
+		responseType:        responseType,
+		messageInput:        messageInput,
+		proposalInput:       proposalInput,
+		recurringScope:      core.RecurringScopeThisInstance,
+	}
+}
+
+// Init initializes the modal
+func (m RespondModal) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+// Helper methods to get dynamic focus indices
+func (m RespondModal) calendarFocusIdx() int {
+	if len(m.event.Calendars) > 1 {
+		return 1
+	}
+	return -1 // Not shown
+}
+
+func (m RespondModal) recurringScopeFocusIdx() int {
+	offset := 1
+	if len(m.event.Calendars) > 1 {
+		offset++
+	}
+	if m.event.IsRecurring() {
+		return offset
+	}
+	return -1 // Not shown
+}
+
+func (m RespondModal) messageFocusIdx() int {
+	offset := 1
+	if len(m.event.Calendars) > 1 {
+		offset++
+	}
+	if m.event.IsRecurring() {
+		offset++
+	}
+	return offset
+}
+
+func (m RespondModal) proposalFocusIdx() int {
+	return m.messageFocusIdx() + 1
+}
+
+func (m RespondModal) maxFocusIdx() int {
+	return m.proposalFocusIdx()
+}
+
+// Update handles messages for the respond modal
+func (m RespondModal) Update(msg tea.Msg) (RespondModal, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
+			m.cancelled = true
+			return m, nil
+
+		case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))):
+			m.cancelled = true
+			return m, nil
+
+		case key.Matches(msg, key.NewBinding(key.WithKeys("enter"))):
+			// Submit the form
+			// Since text inputs are single-line, Enter should submit
+			m.submitted = true
+			return m, nil
+
+		case key.Matches(msg, key.NewBinding(key.WithKeys("tab", "down"))):
+			m.focusIndex++
+			if m.focusIndex > m.maxFocusIdx() {
+				m.focusIndex = 0
+			}
+			m.updateFocus()
+			return m, nil
+
+		case key.Matches(msg, key.NewBinding(key.WithKeys("shift+tab", "up"))):
+			m.focusIndex--
+			if m.focusIndex < 0 {
+				m.focusIndex = m.maxFocusIdx()
+			}
+			m.updateFocus()
+			return m, nil
+
+		case key.Matches(msg, key.NewBinding(key.WithKeys("1"))):
+			if m.focusIndex == 0 {
+				m.responseType = core.ResponseAccept
+				return m, nil
+			}
+
+		case key.Matches(msg, key.NewBinding(key.WithKeys("2"))):
+			if m.focusIndex == 0 {
+				m.responseType = core.ResponseDecline
+				return m, nil
+			}
+
+		case key.Matches(msg, key.NewBinding(key.WithKeys("3"))):
+			if m.focusIndex == 0 {
+				m.responseType = core.ResponseTentative
+				return m, nil
+			}
+
+		case key.Matches(msg, key.NewBinding(key.WithKeys("y", "n"))):
+			// Handle recurring scope toggle
+			if m.event.IsRecurring() && m.focusIndex == m.recurringScopeFocusIdx() {
+				if msg.String() == "y" {
+					m.recurringScope = core.RecurringScopeAllInstances
+				} else {
+					m.recurringScope = core.RecurringScopeThisInstance
+				}
+				return m, nil
+			}
+
+		case key.Matches(msg, key.NewBinding(key.WithKeys("left", "right"))):
+			// Handle calendar selection (only when on calendar picker)
+			if len(m.event.Calendars) > 1 && m.focusIndex == m.calendarFocusIdx() {
+				if msg.String() == "right" {
+					m.selectedCalendarIdx++
+					if m.selectedCalendarIdx >= len(m.event.Calendars) {
+						m.selectedCalendarIdx = 0
+					}
+				} else {
+					m.selectedCalendarIdx--
+					if m.selectedCalendarIdx < 0 {
+						m.selectedCalendarIdx = len(m.event.Calendars) - 1
+					}
+				}
+				// Update calendar ID and response type based on selected calendar
+				m.calendarID = m.event.Calendars[m.selectedCalendarIdx].Calendar.ID
+				// Update pre-selected response based on this calendar's status
+				switch m.event.Calendars[m.selectedCalendarIdx].Status {
+				case core.StatusAccepted:
+					m.responseType = core.ResponseAccept
+				case core.StatusRejected:
+					m.responseType = core.ResponseDecline
+				case core.StatusTentative:
+					m.responseType = core.ResponseTentative
+				}
+				return m, nil
+			}
+		}
+	}
+
+	// Update text inputs if they're focused
+	if m.focusIndex == m.messageFocusIdx() {
+		m.messageInput, cmd = m.messageInput.Update(msg)
+		return m, cmd
+	} else if m.focusIndex == m.proposalFocusIdx() {
+		m.proposalInput, cmd = m.proposalInput.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+// updateFocus updates which field is focused
+func (m *RespondModal) updateFocus() {
+	m.messageInput.Blur()
+	m.proposalInput.Blur()
+
+	if m.focusIndex == m.messageFocusIdx() {
+		m.messageInput.Focus()
+	} else if m.focusIndex == m.proposalFocusIdx() {
+		m.proposalInput.Focus()
+	}
+}
+
+// View renders the respond modal
+func (m RespondModal) View() string {
+	if m.width == 0 {
+		return ""
+	}
+
+	// Modal dimensions
+	modalWidth := 70
+	if m.width < 80 {
+		modalWidth = m.width - 10
+	}
+
+	// Adjust input widths to fit modal
+	inputWidth := modalWidth - 6
+	if inputWidth > 60 {
+		inputWidth = 60
+	}
+	m.messageInput.Width = inputWidth
+	m.proposalInput.Width = inputWidth
+
+	var content strings.Builder
+
+	// Header
+	content.WriteString(lipgloss.NewStyle().
+		Foreground(primaryColor).
+		Bold(true).
+		Render("📅 Respond to Event"))
+	content.WriteString("\n\n")
+
+	// Event title
+	eventTitle := m.event.Title
+	if len(eventTitle) > modalWidth-4 {
+		eventTitle = eventTitle[:modalWidth-7] + "..."
+	}
+	content.WriteString(lipgloss.NewStyle().
+		Foreground(accentColor).
+		Render(eventTitle))
+	content.WriteString("\n")
+
+	// Show current response status if already responded
+	if m.event.Status != core.StatusAwaiting {
+		currentStatus := m.formatCurrentStatus()
+		content.WriteString(lipgloss.NewStyle().
+			Foreground(mutedColor).
+			Italic(true).
+			Render("Current: " + currentStatus))
+	}
+	content.WriteString("\n\n")
+
+	// Section 1: Response type
+	content.WriteString(m.renderResponseTypeSection())
+	content.WriteString("\n")
+
+	// Section 2: Calendar picker (only if multi-calendar event)
+	if len(m.event.Calendars) > 1 {
+		content.WriteString(m.renderCalendarSection())
+		content.WriteString("\n")
+	}
+
+	// Section 3: Recurring scope (only if event is recurring)
+	if m.event.IsRecurring() {
+		content.WriteString(m.renderRecurringScopeSection())
+		content.WriteString("\n")
+	}
+
+	// Section 4: Message
+	content.WriteString(m.renderMessageSection())
+	content.WriteString("\n")
+
+	// Section 5: Proposed time
+	content.WriteString(m.renderProposalSection())
+	content.WriteString("\n\n")
+
+	// Submit/Cancel
+	content.WriteString(m.renderActions())
+
+	// Wrap in modal box
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(primaryColor).
+		Padding(1, 2).
+		Width(modalWidth)
+
+	modal := boxStyle.Render(content.String())
+
+	// Center in screen
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		modal,
+	)
+}
+
+func (m RespondModal) renderResponseTypeSection() string {
+	focusIdx := 0
+	isFocused := m.focusIndex == focusIdx
+
+	// Label changes based on whether this is new or changing response
+	headerLabel := "Response Type"
+	if m.event.Status != core.StatusAwaiting {
+		headerLabel = "Change Response To"
+	}
+
+	var options strings.Builder
+	options.WriteString(m.renderSectionHeader(headerLabel, isFocused))
+	options.WriteString("\n")
+
+	// Option 1: Accept
+	marker := " "
+	if m.responseType == core.ResponseAccept {
+		marker = "●"
+	}
+	acceptStyle := lipgloss.NewStyle()
+	if isFocused && m.responseType == core.ResponseAccept {
+		acceptStyle = acceptStyle.Foreground(accentColor).Bold(true)
+	} else if m.responseType == core.ResponseAccept {
+		acceptStyle = acceptStyle.Foreground(primaryColor)
+	}
+	options.WriteString(acceptStyle.Render(fmt.Sprintf("  %s 1. Accept", marker)))
+	options.WriteString("\n")
+
+	// Option 2: Decline
+	marker = " "
+	if m.responseType == core.ResponseDecline {
+		marker = "●"
+	}
+	declineStyle := lipgloss.NewStyle()
+	if isFocused && m.responseType == core.ResponseDecline {
+		declineStyle = declineStyle.Foreground(accentColor).Bold(true)
+	} else if m.responseType == core.ResponseDecline {
+		declineStyle = declineStyle.Foreground(primaryColor)
+	}
+	options.WriteString(declineStyle.Render(fmt.Sprintf("  %s 2. Decline", marker)))
+	options.WriteString("\n")
+
+	// Option 3: Tentative
+	marker = " "
+	if m.responseType == core.ResponseTentative {
+		marker = "●"
+	}
+	tentativeStyle := lipgloss.NewStyle()
+	if isFocused && m.responseType == core.ResponseTentative {
+		tentativeStyle = tentativeStyle.Foreground(accentColor).Bold(true)
+	} else if m.responseType == core.ResponseTentative {
+		tentativeStyle = tentativeStyle.Foreground(primaryColor)
+	}
+	options.WriteString(tentativeStyle.Render(fmt.Sprintf("  %s 3. Tentative", marker)))
+
+	return options.String()
+}
+
+func (m RespondModal) renderCalendarSection() string {
+	focusIdx := m.calendarFocusIdx()
+	isFocused := m.focusIndex == focusIdx
+
+	var section strings.Builder
+	section.WriteString(m.renderSectionHeader("Respond From Calendar", isFocused))
+	section.WriteString("\n")
+
+	// Show current calendar selection with navigation hint
+	if m.selectedCalendarIdx < len(m.event.Calendars) {
+		currentCal := m.event.Calendars[m.selectedCalendarIdx]
+
+		// Build display string with calendar name and current status
+		calName := currentCal.Calendar.Name
+		statusStr := ""
+		switch currentCal.Status {
+		case core.StatusAccepted:
+			statusStr = " (Currently: Accepted ✓)"
+		case core.StatusRejected:
+			statusStr = " (Currently: Declined ✗)"
+		case core.StatusTentative:
+			statusStr = " (Currently: Tentative ?)"
+		case core.StatusAwaiting:
+			statusStr = " (Awaiting response)"
+		}
+
+		displayText := fmt.Sprintf("  %s%s", calName, statusStr)
+
+		// Style based on focus
+		style := lipgloss.NewStyle()
+		if isFocused {
+			style = style.Foreground(accentColor).Bold(true)
+		} else {
+			style = style.Foreground(primaryColor)
+		}
+
+		section.WriteString(style.Render(displayText))
+		section.WriteString("\n")
+
+		// Show navigation hint when focused
+		if isFocused && len(m.event.Calendars) > 1 {
+			hint := fmt.Sprintf("  ← → to switch (%d/%d)", m.selectedCalendarIdx+1, len(m.event.Calendars))
+			section.WriteString(lipgloss.NewStyle().
+				Foreground(mutedColor).
+				Render(hint))
+		}
+	}
+
+	return section.String()
+}
+
+func (m RespondModal) renderRecurringScopeSection() string {
+	focusIdx := m.recurringScopeFocusIdx()
+	isFocused := m.focusIndex == focusIdx
+
+	var options strings.Builder
+	options.WriteString(m.renderSectionHeader("Apply To", isFocused))
+	options.WriteString("\n")
+
+	// Option 1: This instance only
+	marker := " "
+	if m.recurringScope == core.RecurringScopeThisInstance {
+		marker = "●"
+	}
+	thisStyle := lipgloss.NewStyle()
+	if isFocused && m.recurringScope == core.RecurringScopeThisInstance {
+		thisStyle = thisStyle.Foreground(accentColor).Bold(true)
+	} else if m.recurringScope == core.RecurringScopeThisInstance {
+		thisStyle = thisStyle.Foreground(primaryColor)
+	}
+	options.WriteString(thisStyle.Render(fmt.Sprintf("  %s This event only (n)", marker)))
+	options.WriteString("\n")
+
+	// Option 2: All instances
+	marker = " "
+	if m.recurringScope == core.RecurringScopeAllInstances {
+		marker = "●"
+	}
+	allStyle := lipgloss.NewStyle()
+	if isFocused && m.recurringScope == core.RecurringScopeAllInstances {
+		allStyle = allStyle.Foreground(accentColor).Bold(true)
+	} else if m.recurringScope == core.RecurringScopeAllInstances {
+		allStyle = allStyle.Foreground(primaryColor)
+	}
+	options.WriteString(allStyle.Render(fmt.Sprintf("  %s All events in series (y)", marker)))
+
+	return options.String()
+}
+
+func (m RespondModal) renderMessageSection() string {
+	focusIdx := m.messageFocusIdx()
+	isFocused := m.focusIndex == focusIdx
+
+	var section strings.Builder
+	section.WriteString(m.renderSectionHeader("Message (optional)", isFocused))
+	section.WriteString("\n")
+	section.WriteString(m.messageInput.View())
+
+	return section.String()
+}
+
+func (m RespondModal) renderProposalSection() string {
+	focusIdx := m.proposalFocusIdx()
+	isFocused := m.focusIndex == focusIdx
+
+	var section strings.Builder
+	section.WriteString(m.renderSectionHeader("Propose New Time (optional)", isFocused))
+	section.WriteString("\n")
+	section.WriteString(m.proposalInput.View())
+	section.WriteString("\n")
+
+	// Show validation feedback if user has entered something
+	proposalValue := strings.TrimSpace(m.proposalInput.Value())
+	if proposalValue != "" {
+		validationMsg := m.validateProposalFormat(proposalValue)
+		section.WriteString(validationMsg)
+		section.WriteString("\n")
+	}
+
+	// Format hints
+	hints := lipgloss.NewStyle().
+		Foreground(mutedColor).
+		Render("  Examples: 14:00/15:00  |  2026-03-04T14:00/15:00  |  14:00Z/15:00Z")
+	section.WriteString(hints)
+
+	return section.String()
+}
+
+// validateProposalFormat checks if the proposal has the right format
+func (m RespondModal) validateProposalFormat(proposal string) string {
+	// Quick validation - just check basic format
+	if !strings.Contains(proposal, "/") {
+		return lipgloss.NewStyle().
+			Foreground(errorColor).
+			Render("  ⚠ Missing '/' separator")
+	}
+
+	parts := strings.SplitN(proposal, "/", 2)
+	if len(parts) != 2 {
+		return lipgloss.NewStyle().
+			Foreground(errorColor).
+			Render("  ⚠ Invalid format")
+	}
+
+	// Check if both parts are non-empty
+	start := strings.TrimSpace(parts[0])
+	end := strings.TrimSpace(parts[1])
+	if start == "" || end == "" {
+		return lipgloss.NewStyle().
+			Foreground(errorColor).
+			Render("  ⚠ Both start and end times required")
+	}
+
+	// Check if they look like times (basic pattern matching)
+	if !looksLikeTime(start) {
+		return lipgloss.NewStyle().
+			Foreground(errorColor).
+			Render("  ⚠ Start time doesn't look valid")
+	}
+
+	if !looksLikeTime(end) {
+		return lipgloss.NewStyle().
+			Foreground(errorColor).
+			Render("  ⚠ End time doesn't look valid")
+	}
+
+	// Basic format looks okay
+	return lipgloss.NewStyle().
+		Foreground(primaryColor).
+		Render("  ✓ Format looks good")
+}
+
+// looksLikeTime checks if a string looks like a time value
+// Supports all formats: HH:MM, HH:MM:SS, YYYY-MM-DDTHH:MM, YYYY-MM-DDTHH:MM:SS, RFC3339
+func looksLikeTime(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+
+	// Must contain ":" for time portion
+	if !strings.Contains(s, ":") {
+		return false
+	}
+
+	// Try parsing with the actual time parsers to validate properly
+	// This ensures we validate against the same formats we accept
+	_, err := time.Parse(time.RFC3339, s)
+	if err == nil {
+		return true
+	}
+
+	_, err = time.ParseInLocation("2006-01-02T15:04:05", s, time.Local)
+	if err == nil {
+		return true
+	}
+
+	_, err = time.ParseInLocation("2006-01-02T15:04", s, time.Local)
+	if err == nil {
+		return true
+	}
+
+	_, err = time.ParseInLocation("15:04:05", s, time.Local)
+	if err == nil {
+		return true
+	}
+
+	_, err = time.ParseInLocation("15:04", s, time.Local)
+	if err == nil {
+		return true
+	}
+
+	// No valid format matched
+	return false
+}
+
+func (m RespondModal) renderActions() string {
+	submitStyle := lipgloss.NewStyle().
+		Foreground(primaryColor).
+		Bold(true)
+
+	cancelStyle := lipgloss.NewStyle().
+		Foreground(mutedColor)
+
+	submit := submitStyle.Render("[Enter] Submit")
+	cancel := cancelStyle.Render("[Esc] Cancel")
+
+	return fmt.Sprintf("  %s    %s", submit, cancel)
+}
+
+func (m RespondModal) renderSectionHeader(title string, focused bool) string {
+	style := lipgloss.NewStyle().Bold(true)
+	if focused {
+		style = style.Foreground(accentColor)
+		title = "▶ " + title
+	} else {
+		style = style.Foreground(primaryColor)
+		title = "  " + title
+	}
+	return style.Render(title)
+}
+
+// formatCurrentStatus returns a human-readable current response status
+func (m RespondModal) formatCurrentStatus() string {
+	switch m.event.Status {
+	case core.StatusAccepted:
+		return "Accepted ✓"
+	case core.StatusRejected:
+		return "Declined ✗"
+	case core.StatusTentative:
+		return "Tentative ?"
+	case core.StatusAwaiting:
+		return "Awaiting response"
+	default:
+		return ""
+	}
+}
+
+// GetResponse returns the response options if submitted
+func (m RespondModal) GetResponse() (core.RespondOptions, bool) {
+	if !m.submitted {
+		return core.RespondOptions{}, false
+	}
+
+	opts := core.RespondOptions{
+		Response:       m.responseType,
+		Comment:        strings.TrimSpace(m.messageInput.Value()),
+		RecurringScope: m.recurringScope,
+	}
+
+	return opts, true
+}
+
+// Cancelled returns true if the modal was cancelled
+func (m RespondModal) Cancelled() bool {
+	return m.cancelled
+}
+
+// GetProposalString returns the raw proposal input string
+func (m RespondModal) GetProposalString() string {
+	return strings.TrimSpace(m.proposalInput.Value())
+}


### PR DESCRIPTION
### Summary

Adds interactive event response capability to the TUI, allowing users to accept, decline, or tentatively respond to calendar invitations directly from the terminal interface.

### What's New

**Quick Accept (`a` key)**
- One-click event acceptance without modal
- Works for new invitations and changing existing responses
- Defaults to "this instance only" for recurring events

**Full Respond Modal (`r` key)**
- Response type selector (Accept/Decline/Tentative) with number keys 1/2/3
- Calendar picker for multi-calendar events with arrow key navigation
- Recurring scope selector for event series
- Optional message field (500 char limit)
- Optional proposed time field with smart format detection
- Real-time validation for time proposals using actual parsers
- Status messages that clear on any keypress

### Keyboard Shortcuts Reorganized

- `a` → Quick accept event (new)
- `r` → Full respond modal (was refresh)
- `s` → Sync/refresh events (was split direction)
- `/` → Toggle split direction (was `s`)

### Technical Details

- New `RespondModal` component in `internal/tui/respond.go`
- Dynamic field visibility based on event context (multi-calendar, recurring, etc.)
- Supports multiple time formats: `HH:MM`, `YYYY-MM-DDTHH:MM`, RFC3339
- Validation prevents false positives by using actual time parsers
- Dependencies: Added `charmbracelet/bubbles/textinput` for form fields

### Documentation Updates

- Updated README to mention TUI respond capability
- Updated `docs/usage.md` with new keyboard shortcuts

---

**Related Issue:** Closes #4  (Phase 1 - Google Calendar response implementation)